### PR TITLE
Fix dictionary initialization

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -89,7 +89,6 @@ disable=raw-checker-failed,
         C0114,
         C0116,
         W0703,
-        R0201,
         R0903,
         W0212
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -90,7 +90,8 @@ disable=raw-checker-failed,
         C0116,
         W0703,
         R0903,
-        W0212
+        W0212,
+        R0201
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/sdv/model.py
+++ b/sdv/model.py
@@ -16,7 +16,6 @@
 
 import asyncio
 import contextvars
-import inspect
 import logging
 from typing import Generic, List, Type, TypeVar
 

--- a/sdv/model.py
+++ b/sdv/model.py
@@ -128,7 +128,7 @@ class ModelCollection(Generic[TModel]):
         self.specs = model_refs
 
     def element_at(self, *args) -> TModel:
-        if args.__len__() != self.specs.__len__():
+        if len(args) != len(self.specs):
             raise Exception("Indexes length does not match specs length")
 
         segments = []

--- a/sdv/model.py
+++ b/sdv/model.py
@@ -85,9 +85,8 @@ class Dictionary(ModelReferences):
 
     def __init__(self, list_type: Type):
         self.instances = []
-        for i in inspect.getmembers(list_type):
-            if not i[0].startswith("_"):
-                self.instances.append(i[1])
+        for i in list_type:
+            self.instances.append(i)
 
     def to_string(self, selector) -> str:
         if selector not in self.instances:

--- a/tests/unit/model_test.py
+++ b/tests/unit/model_test.py
@@ -894,7 +894,7 @@ def get_vehicle_instance():
                 [NamedRange("Row", 1, 2), Dictionary(DoorSides)],
                 Door(self),
             )
-    
+
     class Trunk(Model):
         """Trunk Class"""
 

--- a/tests/unit/model_test.py
+++ b/tests/unit/model_test.py
@@ -720,8 +720,14 @@ def test_path_instances_range2():
 
 def test_path_instances_range_list():
     vehicle = get_vehicle_instance()
-    path = vehicle.Cabin.Door.element_at(1, DoorSides.LEFT).IsOpen.get_path()
+    path = vehicle.Cabin.Door.element_at(1, DoorSides[0]).IsOpen.get_path()
     assert path == "Vehicle.Cabin.Door.Row1.Left.IsOpen"
+
+
+def test_path_instances_dictionary():
+    vehicle = get_vehicle_instance()
+    path = vehicle.Body.Trunk.element_at("Rear").IsOpen.get_path()
+    assert path == "Vehicle.Body.Trunk.Rear.IsOpen"
 
 
 def test_path_unknown_list_entry():
@@ -742,11 +748,8 @@ def test_path_out_of_range():
         assert e.args[0] == "5 is not in range 1-2"
 
 
-class DoorSides:
-    """DoorSides Class"""
-
-    LEFT = "Left"
-    RIGHT = "Right"
+DoorSides = ["Left", "Right"]
+TrunkOptions = ["Front", "Rear"]
 
 
 class AsyncIter:
@@ -891,6 +894,21 @@ def get_vehicle_instance():
                 [NamedRange("Row", 1, 2), Dictionary(DoorSides)],
                 Door(self),
             )
+    
+    class Trunk(Model):
+        """Trunk Class"""
+
+        def __init__(self, parent):
+            super().__init__(parent)
+            self.IsOpen = DataPointBoolean("IsOpen", self)
+            self.IsLocked = DataPointBoolean("IsLocked", self)
+
+    class Body(Model):
+        """Body Class"""
+
+        def __init__(self, parent):
+            super().__init__(parent)
+            self.Trunk = ModelCollection[Trunk]([Dictionary(TrunkOptions)], Trunk(self))
 
     class Vehicle(Model):
         """Mock Class"""
@@ -899,6 +917,7 @@ def get_vehicle_instance():
             super().__init__()
             self.Speed = DataPointFloat("Speed", self)
             self.Cabin = Cabin(self)
+            self.Body = Body(self)
             self.String = DataPointString("String", self)
             self.Bool = DataPointBoolean("Bool", self)
             self.Int8 = DataPointInt8("Int8", self)


### PR DESCRIPTION
## Describe your changes
SDK Dictionary initialization is now using simple Lists of strings and is compatible with the current version of the Python Vehicle Model Generator.

## Issue ticket number and link

Fixes #6

## Checklist - Manual tasks

* [x] Examples are executing successfully
* [x] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] ~~Created/updated integration tests.~~ does not apply
* [x] Devcontainer can be opened successfully
* [ ] ~~Devcontainer can be opened successfully behind a corporate proxy~~ no changes were made
* [x] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas), see https://github.com/eclipse-velocitas/velocitas-docs/issues/17
