### PR TITLE
Downgrade Dapr CLI to version 1.7.1 due to Dapr CLI bug #1043 (https:…

### DIFF
--- a/prerequisite_settings.json
+++ b/prerequisite_settings.json
@@ -19,7 +19,7 @@
     },
     "dapr": {
         "cli": {
-            "version": "1.8.0"
+            "version": "1.7.1"
         },
         "runtime": {
             "version": "1.8.1"


### PR DESCRIPTION
…//github.com/dapr/cli/issues/1043)

## Describe your changes

Downgrading Dapr CLI to v1.7.1 because `dapr init` is not working in Dapr CLI v1.8.0: It cannot download Dapr runtime.

## Issue ticket number and link

See bug ticket: https://github.com/dapr/cli/issues/1043

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
