### PR TITLE
[11026] Fix GitHub workflow

### DIFF
--- a/.github/workflows/check-notice-file.yml
+++ b/.github/workflows/check-notice-file.yml
@@ -16,14 +16,15 @@ name: Check licenses
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
+  # Run only on branches/commits and not tags
     branches:
       - main
 
 jobs:
-  check-licenses:
+  push_to_main:
     runs-on: ubuntu-latest
-    name: Check Software Licenses
+    name: Check Software Licenses and Notice file
 
     steps:
       - name: Checkout repository
@@ -39,9 +40,9 @@ jobs:
           ref: v1
           path: .github/actions/license-check
 
-      - name: Run License Checker
+      - name: Run License Checker and Check the Notice file
         uses: ./.github/actions/license-check
         with:
           config-file-path: ./.licensechecker.yml
           fail-on-violation: false
-          generate-notice-file: false
+          notice-file-name: "NOTICE-3RD-PARTY-CONTENT"

--- a/.github/workflows/update-notice-file.yml
+++ b/.github/workflows/update-notice-file.yml
@@ -12,26 +12,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Check licenses
+name: Update license notice file
 
 on:
   workflow_dispatch:
   push:
-  # Run only on branches/commits and not tags
+    # Run only on branches/commits and not tags
     branches:
       - main
 
 jobs:
-  push_to_main:
+  update_notice_file:
     runs-on: ubuntu-latest
-    name: Check Software Licenses and Notice file
+    name: Check and update Licenses Notice file
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Clone License Check Repo
         uses: actions/checkout@v2
@@ -40,7 +39,7 @@ jobs:
           ref: v1
           path: .github/actions/license-check
 
-      - name: Run License Checker and Check the Notice file
+      - name: Run License Checker to update the notice file
         uses: ./.github/actions/license-check
         with:
           config-file-path: ./.licensechecker.yml


### PR DESCRIPTION
## Describe your changes

- Split the license workflow to multiple stages, PullRequest and Merge
- Trigger the notice file update only from the Github push to main branch event and not from the PR anymore.

## Issue ticket number and link
- AB#11026

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
