### PR TITLE
Adapt log message when dapr sidecar returns 500

### DIFF
--- a/sdv/dapr/client.py
+++ b/sdv/dapr/client.py
@@ -72,7 +72,7 @@ async def wait_for_sidecar() -> None:
                     logger.error("Unexpected error from dapr sidecar: %d", error.code)
                 await asyncio.sleep(0.1)
             except BaseException as error:
-                logger.debug("%s", str(error))
+                logger.error("%s", str(error))
                 await asyncio.sleep(0.1)
         else:
             await asyncio.sleep(0.1)


### PR DESCRIPTION
## Describe your changes

Improves the log message when dapr sidecar is not ready yet instead of directly logging INTERNAL_SERVER_ERROR.

## Issue ticket number and link

#34 

## Checklist - Manual tasks

* [x] Examples are executing successfully
* [x] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [x] Created/updated integration tests.
* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully
* [x] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
