### PR TITLE
add constraints for opentelemetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     "opentelemetry-distro<=0.36b0",
     "opentelemetry-instrumentation-logging<=0.36b0",
     "opentelemetry-sdk<=1.15.0",
-    "opentelemetry-api<=1.15.0"
+    "opentelemetry-api<=1.15.0",
 ]
 
 extra_requirements = {

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@ requirements = [
     "protobuf>=3.19.4",
     "dapr>=1.6.0",
     "paho-mqtt>=1.6.1",
-    "opentelemetry-api>=1.11.1",
-    "opentelemetry-sdk>=1.11.1",
-    "opentelemetry-distro>=0.31b0",
-    "opentelemetry-instrumentation-logging>=0.31b0",
+    "opentelemetry-distro<=0.36b0",
+    "opentelemetry-instrumentation-logging<=0.36b0",
+    "opentelemetry-sdk<=1.15.0",
+    "opentelemetry-api<=1.15.0"
 ]
 
 extra_requirements = {
@@ -70,7 +70,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="sdv",
-    version="0.8.0",
+    version="0.8.1",
     description="A Python SDK for Vehicle app",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Describe your changes
The latest update of opentelemetry breaks the deployment. That's why I added constraints, to exclude the latest version.

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
