### PR TITLE
Update devContainer base image to v0.1.2 and dapr runtinme to v1.10.3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.1.0
+FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/python:v0.1.2
 
 # Force dapr to use localhost traffic
 ENV DAPR_HOST_IP="127.0.0.1"

--- a/prerequisite_settings.json
+++ b/prerequisite_settings.json
@@ -27,7 +27,7 @@
             "version": "1.10.0"
         },
         "runtime": {
-            "version": "1.10.2"
+            "version": "1.10.3"
         }
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+# Copyright (c) 2022-2023 Robert Bosch GmbH and Microsoft Corporation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at


### PR DESCRIPTION
## Describe your changes

* Update the base-image of the devContainer to v0.1.2 (for being in sync with C++ SDK/template)
* Update dapr runtime version to 1.10.3 (like used in devenv-runtimes)

## Issue ticket number and link

AB#15008

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
