### PR TITLE
Fixes for seat-adjuster example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ These examples demonstrate how to use the Python Vehicle App SDK:
 | [Dynamic Rule](./examples/dynamic-rule/) | Create a Vehicle Data Broker rule with the fluent query methods.
 | [Static Rule](./examples/static-rule/) | Create a Vehicle Data Broker rule with the subscribe_to_data_point annotation.
 | [VDB Queries](./examples/vdb-queries/) | Demonstrates various aspects of creating Vehicle Data Broker queries.
-| [Seat Adjuster](./examples/seat-adjuster/) | Seat-Adjuster App that demonstrates MQTT communication and seat control via actuator data points.<br>(i) This example can only be run from the [Vehicle App Template](https://github.com/eclipse-velocitas/vehicle-app-python-template).
+| [Seat Adjuster](./examples/seat-adjuster/) | Seat-Adjuster App that demonstrates MQTT communication and seat control via actuator data points.<br>:point_right: This example can only be run from the [Vehicle App Template](https://github.com/eclipse-velocitas/vehicle-app-python-template). :point_left:
 
 All examples (except the Seat Adjuster) can be run via
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ The `Vehicle App SDK` reduces the effort required to implement Vehicle Apps by u
 
 This includes the following packages:
 
-* [sdv.model](./sdv/model.py) - Vehicle Model ontology
-* [sdv.dapr](./sdv/dapr) - Dapr middleware integration
-* [sdv.conf](./sdv/config.py) - Vehicle App configuration
 * [sdv.vehicle_app](./sdv/vehicle_app.py) - Vehicle App abstraction
+* [sdv.model](./sdv/model.py) - Vehicle Model ontology
+* [sdv.config](./sdv/config.py) - Vehicle App configuration
+* [sdv.base](./sdv/base.py) - Base classes for middleware abstraction
+* [sdv.dapr](./sdv/dapr) - Dapr middleware integration
+* [sdv.native](./sdv/native) - Native middleware definition
 * [sdv.vdb](./sdv/vdb) - Vehicle Data Broker integration
 * [sdv.test](./sdv/test) - Integration test support
 * [sdv.util](./sdv/util) - Logging and other utilities

--- a/examples/seat-adjuster/Dockerfile
+++ b/examples/seat-adjuster/Dockerfile
@@ -20,6 +20,7 @@ FROM --platform=$TARGETPLATFORM python:3.10-slim-bullseye@sha256:1ee6094f44c6778
 RUN apt-get update && apt-get install -y binutils
 
 COPY ./app /app
+COPY ./gen/vehicle_model /vehicle_model
 
 # Remove this installation for Arm64 once staticx has a prebuilt wheel for Arm64
 RUN /bin/bash -c 'set -ex && \
@@ -31,11 +32,12 @@ RUN /bin/bash -c 'set -ex && \
     fi'
 
 RUN apt-get install -y git
-RUN pip3 install --no-cache-dir pyinstaller \
+RUN pip3 install --no-cache-dir pyinstaller==5.9.0 \
     && pip3 install --no-cache-dir patchelf==0.17.0.0 \
     && pip3 install --no-cache-dir staticx \
     && pip3 install --no-cache-dir -r ./app/requirements.txt \
-    && pip3 install --no-cache-dir -r ./app/requirements-links.txt
+    && pip3 install --no-cache-dir -r ./app/requirements-links.txt \
+    && pip3 install --no-cache-dir /vehicle_model
 
 WORKDIR /app
 

--- a/examples/seat-adjuster/README.md
+++ b/examples/seat-adjuster/README.md
@@ -22,9 +22,10 @@ It is possible to import and run this example from your app development reposito
 
 ## Executing with "native" middleware (without Dapr runtime)
 
-If you like to run this example without using Dapr as middleware, you may need to provide some environment variables to the seat-adjuster process, which define where to find the required runtime components:
+If you like to run this example without using Dapr as middleware, you may need to provide some environment variables to the seat-adjuster process, which define the middleware type being _native_ and where to find the required runtime components:
 
-| Variable name                   | Default value            | Description
-|---------------------------------|--------------------------|-------------
-| `SDV_MQTT_ADDRESS`              | `mqtt://localhost:1883`  | Address (and port) of the MQTT broker
-| `SDV_VEHICLEDATABROKER_ADDRESS` | `grpc://localhost:55555` | Address (and port) of the KUKSA Data Broker
+| Variable name                   | Default value              | Description
+|---------------------------------|----------------------------|-------------
+| `SDV_MIDDLEWARE_TYPE`           | `"dapr"`                   | Defines the middleware type -> set to `"native"`
+| `SDV_MQTT_ADDRESS`              | `"mqtt://localhost:1883"`  | Address (and port) of the MQTT broker
+| `SDV_VEHICLEDATABROKER_ADDRESS` | `"grpc://localhost:55555"` | Address (and port) of the KUKSA Data Broker

--- a/examples/seat-adjuster/README.md
+++ b/examples/seat-adjuster/README.md
@@ -24,5 +24,7 @@ It is possible to import and run this example from your app development reposito
 
 If you like to run this example without using Dapr as middleware, you may need to provide some environment variables to the seat-adjuster process, which define where to find the required runtime components:
 
-`SDV_MQTT_ADDRESS` - address (and port) of the MQTT broker, default is `mqtt://localhost:1883`
-`SDV_VEHICLEDATABROKER_ADDRESS` - address (and port) of the KUKSA Data Broker, default is `grpc://localhost:55555`
+| Variable name                   | Default value            | Description
+|---------------------------------|--------------------------|-------------
+| `SDV_MQTT_ADDRESS`              | `mqtt://localhost:1883`  | Address (and port) of the MQTT broker
+| `SDV_VEHICLEDATABROKER_ADDRESS` | `grpc://localhost:55555` | Address (and port) of the KUKSA Data Broker

--- a/examples/seat-adjuster/README.md
+++ b/examples/seat-adjuster/README.md
@@ -1,10 +1,28 @@
 # Seat-adjuster example
 
+:warning: This example is currently not executable from within the vehicle-app-pytthon-sdk's devContainer. Please use the "import example" feature of the related [vehicle-app-python-template repository](https://github.com/eclipse-velocitas/vehicle-app-python-template). Also, building the docker container for this example needs to be done after the import within the Python template's devContainer.
 
-## Launch the seat-adjuster example
 
-```bash
-cd examples/seat-adjuster/src
+## Run this example from your Python app development repo
 
-dapr run --app-id seatadjuster --app-protocol grpc --app-port 50008 --config ../../.dapr/config.yaml --resources-path ../../.dapr/components  python3 main.py
-```
+It is possible to import and run this example from your app development repository, which you already have created or could create from our [vehicle-app-python-template repository](https://github.com/eclipse-velocitas/vehicle-app-python-template).
+
+1. Importing the example
+
+   Use the VS Code task `Import example app from SDK` (to get there press `Ctrl+Shift+P` and select `Tasks: Run Task`) and choose `seat-adjuster` from the list.
+
+   :warning: Make sure you have commited or stash all your possible changes within the `app` folder, because the files of that folder will be overwritten by the files of this example.
+
+2. Running this example with Dapr middleware
+
+   Use the VS Code tasks `Local Runtime - Up` and `Local Runtime - Run VehicleApp` to start the necessary runtime components and this app itself.
+
+   Alternatively, the app can also be deployed in a k3d runtime - use task `K3D Runtime - Deploy VehicleApp`.
+
+
+## Executing with "native" middleware (without Dapr runtime)
+
+If you like to run this example without using Dapr as middleware, you may need to provide some environment variables to the seat-adjuster process, which define where to find the required runtime components:
+
+`SDV_MQTT_ADDRESS` - address (and port) of the MQTT broker, default is `mqtt://localhost:1883`
+`SDV_VEHICLEDATABROKER_ADDRESS` - address (and port) of the KUKSA Data Broker, default is `grpc://localhost:55555`

--- a/examples/seat-adjuster/README.md
+++ b/examples/seat-adjuster/README.md
@@ -29,3 +29,20 @@ If you like to run this example without using Dapr as middleware, you may need t
 | `SDV_MIDDLEWARE_TYPE`           | `"dapr"`                   | Defines the middleware type -> set to `"native"`
 | `SDV_MQTT_ADDRESS`              | `"mqtt://localhost:1883"`  | Address (and port) of the MQTT broker
 | `SDV_VEHICLEDATABROKER_ADDRESS` | `"grpc://localhost:55555"` | Address (and port) of the KUKSA Data Broker
+
+
+## Building a Docker image
+
+This example app provides a Dockerfile to enable creating a Docker container image to run it.
+The image must be build passing the repositories root folder as build context, e.g.:
+
+``` bash
+docker build -f app/Dockerfile .
+```
+
+:warning: If your build environment works behind (corporate) **proxy**, please remember telling docker your proxy configuration.
+If you've set the respective environment variables, this might work:
+
+``` bash
+docker build -f app/Dockerfile . --build-arg http_proxy --build-arg HTTP_PROXY --build-arg https_proxy --build-arg HTTPS_PROXY --build-arg no_proxy --build-arg NO_PROXY
+```

--- a/examples/seat-adjuster/requirements-links.txt
+++ b/examples/seat-adjuster/requirements-links.txt
@@ -1,1 +1,1 @@
-git+https://github.com/eclipse-velocitas/vehicle-app-python-sdk.git@v0.9.0
+git+https://github.com/eclipse-velocitas/vehicle-app-python-sdk.git@v0.9.1

--- a/examples/seat-adjuster/src/main.py
+++ b/examples/seat-adjuster/src/main.py
@@ -53,7 +53,7 @@ class SeatAdjusterApp(VehicleApp):
 
     async def on_start(self):
         """Run when the vehicle app starts"""
-        await self.Vehicle.Cabin.Seat.Row(1).Pos(1).Position.subscribe(
+        await self.Vehicle.Cabin.Seat.Row1.Pos1.Position.subscribe(
             self.on_seat_position_changed
         )
 
@@ -64,7 +64,7 @@ class SeatAdjusterApp(VehicleApp):
             json.dumps(
                 {
                     "position": data.get(
-                        self.Vehicle.Cabin.Seat.Row(1).Pos(1).Position
+                        self.Vehicle.Cabin.Seat.Row1.Pos1.Position
                     ).value
                 }
             ),

--- a/examples/seat-adjuster/src/main.py
+++ b/examples/seat-adjuster/src/main.py
@@ -62,11 +62,7 @@ class SeatAdjusterApp(VehicleApp):
         await self.publish_event(
             response_topic,
             json.dumps(
-                {
-                    "position": data.get(
-                        self.Vehicle.Cabin.Seat.Row1.Pos1.Position
-                    ).value
-                }
+                {"position": data.get(self.Vehicle.Cabin.Seat.Row1.Pos1.Position).value}
             ),
         )
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="sdv",
-    version="0.9.0",
+    version="0.9.1",
     description="A Python SDK for Vehicle app",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Describe your changes

* Make hint that seat-adjuster example can only be run in template repository more prominent in main README
* Explain how to import and run seat-adjuster example in template repo in that example's README
* Remove usage of bracket operators for seat row and pos as quick fix for https://github.com/eclipse-velocitas/vehicle-app-python-template/issues/159
* Quickfix of Dockerfile: Add missing inclusion of the generated vehicle model

## Issue ticket number and link

* Fix for #79 and #82
* Quick fix for #84: With that the Dockerfile is not buildable "stand-alone", but can be build from [vehicle-app-python-template](https://github.com/eclipse-velocitas/vehicle-app-python-template) (and instances). Explanation added in examples README.

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
