### PR TITLE
[Fix] Reproduce generation of existing gRPC stubs

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -316,6 +316,15 @@
 			"group": "none",
 			"isBackground": false,
 			"problemMatcher": []
+		},
+		{
+			"label": "(Re-) generate gRPC stubs",
+			"detail": "Re-generates the gRPC stubs located in sdv/proto folder",
+			"type": "shell",
+			"command": "./generate-grpc-stubs.sh",
+			"group": "none",
+			"isBackground": false,
+			"problemMatcher": []
 		}
 	],
 	"inputs": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,9 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 * When you make changes to existing protocol buffer files, regenerate the python descriptors with the following command:
 
    ```bash
-   python3 -m grpc_tools.protoc -I sdv/proto --grpc_python_out=./sdv/proto --python_out=./sdv/proto --mypy_out=./sdv/proto sdv/proto/*/*/*.proto
+   ./generate-grpc-stubs.sh
    ```
-   Afterwards adjust relative imports as needed.
+   or use the corresponding VSCode task.
 * Make sure you include test cases and new examples for non-trivial features.
 * Make sure test cases provide sufficient code coverage (see GitHub actions for minimal accepted coverage).
 * Install and run [pre-commit](https://pre-commit.com/) to automatically check for style guide issues.

--- a/generate-grpc-stubs.sh
+++ b/generate-grpc-stubs.sh
@@ -1,0 +1,25 @@
+#!/bin/zsh
+# Copyright (c) 2023 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+echo "#######################################################"
+echo "### Generating gRPC stubs from proto files          ###"
+echo "#######################################################"
+
+ROOT_DIR=$( realpath "$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )" )
+
+python3 -m grpc_tools.protoc -I ./sdv/proto --grpc_python_out=./sdv/proto --python_out=./sdv/proto --mypy_out=./sdv/proto ./sdv/proto/**/*.proto
+mv -f ./sdv/proto/**/*.py ./sdv/proto
+mv -f ./sdv/proto/**/*.pyi ./sdv/proto
+sed -i -e 's/from sdv\..* import/from sdv.proto import/g' -e 's/import sdv\..*\./import sdv.proto./g' ./sdv/proto/*.py*

--- a/sdv/proto/sdv/databroker/v1/broker.proto
+++ b/sdv/proto/sdv/databroker/v1/broker.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package sdv.databroker.v1;
 
-import "types.proto";
+import "sdv/databroker/v1/types.proto";
 
 service Broker {
   // Request a set of datapoints (values)

--- a/sdv/proto/sdv/databroker/v1/collector.proto
+++ b/sdv/proto/sdv/databroker/v1/collector.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-import "types.proto";
+import "sdv/databroker/v1/types.proto";
 
 package sdv.databroker.v1;
 


### PR DESCRIPTION
## Describe your changes

The process to generate the data broker gRPC stubs from the corresponding proto files is not working as it is described in CONTRIBUTING.md. This fix provides a working solution.

## Issue ticket number and link

## Checklist - Manual tasks

<!--
Please check which manual tasks have bee performed as part of this pull request.
-->

* [ ] Examples are executing successfully
* [ ] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
* [ ] Created/updated integration tests.
* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully
* [ ] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
