### PR TITLE
Rename component vehicle-model-lifecycle to vehicle-signal-interface

### DIFF
--- a/.project-creation/templates/.vscode/tasks.json
+++ b/.project-creation/templates/.vscode/tasks.json
@@ -172,7 +172,7 @@
 			"label": "(Re-)generate vehicle model",
 			"detail": "(Re-)generates the vehicle model from source files specified in the AppManifest.",
 			"type": "shell",
-			"command": "velocitas exec vehicle-model-lifecycle download-vspec && velocitas exec vehicle-model-lifecycle generate-model",
+			"command": "velocitas exec vehicle-signal-interface download-vspec && velocitas exec vehicle-signal-interface generate-model",
 			"group": "none",
 			"presentation": {
 				"reveal": "always",


### PR DESCRIPTION
This PR renames the component call vehicle-model-lifecycle to vehicle-signal-interface

could only be merged after https://github.com/eclipse-velocitas/devenv-devcontainer-setup/pull/55 and new tag