### PR TITLE
Add subscribe-performance test app

### DIFF
--- a/examples/performance-subscribe/AppManifest.json
+++ b/examples/performance-subscribe/AppManifest.json
@@ -1,6 +1,6 @@
 {
     "manifestVersion": "v1",
-    "name": "dynamic-rule",
+    "name": "performance-subscribe",
     "interfaces": [
         {
             "type": "vehicle-signal-interface",

--- a/examples/performance-subscribe/AppManifest.json
+++ b/examples/performance-subscribe/AppManifest.json
@@ -1,0 +1,16 @@
+{
+    "manifestVersion": "v1",
+    "name": "dynamic-rule",
+    "interfaces": [
+        {
+            "type": "vehicle-signal-interface",
+            "config": {
+                "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v4.1/vss_rel_4.1.json",
+                "datapoints": {
+                    "required": [
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/examples/performance-subscribe/README.md
+++ b/examples/performance-subscribe/README.md
@@ -26,4 +26,4 @@ The following format is mandatory for the input file:
 }
 ```
 
-Signals which are not available will be printed in the console as a warning. 
+Signals which are not available will be printed in the console as a warning.

--- a/examples/performance-subscribe/README.md
+++ b/examples/performance-subscribe/README.md
@@ -1,0 +1,29 @@
+## Usage
+
+1) Create a .json file named: "subscription_signals.json"
+2) Place it in the same folder as the binary
+3) Exeucute the binary e.g. "./sampleapp"
+4) Check the console output for the timestamps: "<Timestamp> - <Signal_Name> - <Value>"
+
+## .json format
+
+The following format is mandatory for the input file:
+
+```
+{
+  "signals": [
+    {
+      "path": "Vehicle.LowVoltageBattery.CurrentVoltage"
+    },
+    {
+      "path": "Vehicle.LowVoltageBattery.CurrentCurrent"
+    },
+    {
+      "path": "Vehicle.Speed"
+    },
+    ...
+  ]
+}
+```
+
+Signals which are not available will be printed in the console as a warning. 

--- a/examples/performance-subscribe/src/main.py
+++ b/examples/performance-subscribe/src/main.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import logging
+import signal
+from datetime import datetime
+
+from sdv_model import Vehicle, vehicle  # type: ignore
+
+from velocitas_sdk.model import DataPoint
+from velocitas_sdk.util.log import (  # type: ignore
+    get_opentelemetry_log_factory,
+    get_opentelemetry_log_format,
+)
+from velocitas_sdk.vdb.reply import DataPointReply
+from velocitas_sdk.vehicle_app import VehicleApp
+
+# Configure the VehicleApp logger with the necessary log config and level.
+logging.setLogRecordFactory(get_opentelemetry_log_factory())
+logging.basicConfig(format=get_opentelemetry_log_format())
+logging.getLogger().setLevel("DEBUG")
+logger = logging.getLogger(__name__)
+
+GET_SPEED_REQUEST_TOPIC = "sampleapp/getSpeed"
+GET_SPEED_RESPONSE_TOPIC = "sampleapp/getSpeed/response"
+DATABROKER_SUBSCRIPTION_TOPIC = "sampleapp/currentSpeed"
+
+
+class PerformanceTestApp(VehicleApp):
+    """
+    A sample vehicle app that subscribes to a list of signals (from a file) and prints
+    the values + timestamps of the signals.
+    """
+
+    def __init__(self, vehicle_client: Vehicle):
+        super().__init__()
+        self.Vehicle = vehicle_client
+
+    async def on_start(self):
+        # The file path may need to be updated based on the location of the file.
+        test_signals_json = self.read_json("subscription_signals.json")
+        signals_json = test_signals_json["signals"]
+
+        for signal_json in signals_json:
+            signal_str = signal_json["path"]
+            await self.subscribe(signal_str)
+
+    def read_json(self, file_path: str):
+        with open(file_path, "r") as file:
+            return json.load(file)
+
+    async def subscribe(self, signal_str: str):
+        try:
+            node: DataPoint = self.Vehicle.getNode(signal_str)  # type: ignore
+            await node.subscribe(self.on_node_change)
+        except AttributeError:
+            print(f"Signal {signal_str} not found in the vehicle model.")
+
+    async def on_node_change(self, data: DataPointReply):
+        current_timestamp = datetime.now()
+
+        datapoint_str = data.reply.fields.popitem()[0]
+        node = self.Vehicle.getNode(datapoint_str=datapoint_str)
+        data_point_value = data.get(node).value  # type: ignore
+
+        print(f"{current_timestamp.time()} - {node.name} - {data_point_value}")
+
+
+async def main():
+    """Main function"""
+    logger.info("Starting SampleApp...")
+    # Constructing SampleApp and running it.
+    vehicle_app = PerformanceTestApp(vehicle)
+    await vehicle_app.run()
+
+
+LOOP = asyncio.get_event_loop()
+LOOP.add_signal_handler(signal.SIGTERM, LOOP.stop)
+LOOP.run_until_complete(main())
+LOOP.close()

--- a/examples/performance-subscribe/subscription_signals.json
+++ b/examples/performance-subscribe/subscription_signals.json
@@ -1,0 +1,307 @@
+{
+  "signals": [
+    {
+      "path": "Vehicle.LowVoltageBattery.CurrentVoltage"
+    },
+    {
+      "path": "Vehicle.LowVoltageBattery.CurrentCurrent"
+    },
+    {
+      "path": "Vehicle.Speed"
+    },
+    {
+      "path": "Vehicle.TraveledDistance"
+    },
+    {
+      "path": "Vehicle.TraveledDistanceSinceStart"
+    },
+    {
+      "path": "Vehicle.TripDuration"
+    },
+    {
+      "path": "Vehicle.IsBrokenDown"
+    },
+    {
+      "path": "Vehicle.IsMoving"
+    },
+    {
+      "path": "Vehicle.AverageSpeed"
+    },
+    {
+      "path": "Vehicle.Acceleration.Longitudinal"
+    },
+    {
+      "path": "Vehicle.Acceleration.Lateral"
+    },
+    {
+      "path": "Vehicle.Acceleration.Vertical"
+    },
+    {
+      "path": "Vehicle.AngularVelocity.Roll"
+    },
+    {
+      "path": "Vehicle.AngularVelocity.Pitch"
+    },
+    {
+      "path": "Vehicle.AngularVelocity.Yaw"
+    },
+    {
+      "path": "Vehicle.CurrentOverallWeight"
+    },
+    {
+      "path": "Vehicle.Trailer.IsConnected"
+    },
+    {
+      "path": "Vehicle.CurrentLocation.Latitude"
+    },
+    {
+      "path": "Vehicle.CurrentLocation.Longitude"
+    },
+    {
+      "path": "Vehicle.CurrentLocation.Heading"
+    },
+    {
+      "path": "Vehicle.CurrentLocation.HorizontalAccuracy"
+    },
+    {
+      "path": "Vehicle.CurrentLocation.Altitude"
+    },
+    {
+      "path": "Vehicle.CurrentLocation.VerticalAccuracy"
+    },
+    {
+      "path": "Vehicle.Powertrain.AccumulatedBrakingEnergy"
+    },
+    {
+      "path": "Vehicle.Powertrain.Range"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.OilLifeRemaining"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.IsRunning"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.Speed"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.EngineHours"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.IdleHours"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.ECT"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.EOT"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.MAP"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.MAF"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.TPS"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.EOP"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.Power"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.Torque"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.DieselExhaustFluid.Level"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.DieselExhaustFluid.Range"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.DieselExhaustFluid.IsLevelLow"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.InletTemperature"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.OutletTemperature"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.DeltaPressure"
+    },
+    {
+      "path": "Vehicle.Powertrain.CombustionEngine.Displacement"
+    },
+    {
+      "path": "Vehicle.Powertrain.FuelSystem.Range"
+    },
+    {
+      "path": "Vehicle.Powertrain.FuelSystem.InstantConsumption"
+    },
+    {
+      "path": "Vehicle.Powertrain.FuelSystem.AverageConsumption"
+    },
+    {
+      "path": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart"
+    },
+    {
+      "path": "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled"
+    },
+    {
+      "path": "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow"
+    },
+    {
+      "path": "Vehicle.Body.Raindetection.Intensity"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.DriveCurrent"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.IsWiping"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.IsEndingWipeCycle"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.IsWiperError"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.IsPositionReached"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.IsBlocked"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.IsOverheated"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.WiperWear"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.IsWipersWorn"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.WasherFluid.IsLevelLow"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.WasherFluid.Level"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.DriveCurrent"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.IsWiping"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.IsEndingWipeCycle"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.IsWiperError"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.IsPositionReached"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.IsBlocked"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.IsOverheated"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.Intensity"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.Frequency"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.Wiping.System.ActualPosition"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Front.IsHeatingOn"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.Intensity"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.Frequency"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.TargetPosition"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.Wiping.System.ActualPosition"
+    },
+    {
+      "path": "Vehicle.Body.Windshield.Rear.IsHeatingOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.IsHighBeamSwitchOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.Beam.Low.IsOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.Beam.High.IsOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.Running.IsOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.Backup.IsOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.Parking.IsOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.Fog.Rear.IsOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.Fog.Front.IsOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.LicensePlate.IsOn"
+    },
+    {
+      "path": "Vehicle.Body.Lights.Hazard.IsSignaling"
+    },
+    {
+      "path": "Vehicle.Body.Lights.DirectionIndicator.Left.IsSignaling"
+    },
+    {
+      "path": "Vehicle.Body.Lights.DirectionIndicator.Right.IsSignaling"
+    },
+    {
+      "path": "Vehicle.Chassis.ParkingBrake.IsEngaged"
+    },
+    {
+      "path": "Vehicle.Chassis.SteeringWheel.Tilt"
+    },
+    {
+      "path": "Vehicle.Chassis.SteeringWheel.Extension"
+    },
+    {
+      "path": "Vehicle.Body.Trunk.Rear.IsLightOn"
+    },
+    {
+      "path": "Vehicle.Body.Trunk.Front.IsLightOn"
+    },
+    {
+      "path": "Vehicle.Cabin.Light.IsDomeOn"
+    },
+    {
+      "path": "Vehicle.Cabin.Seat.Row1.PassengerSide.Heating"
+    },
+    {
+      "path": "Vehicle.Cabin.Seat.Row1.PassengerSide.Massage"
+    },
+    {
+      "path": "Vehicle.Cabin.Seat.Row1.PassengerSide.Position"
+    }
+  ]
+}

--- a/examples/performance-subscribe/tests/__init__.py
+++ b/examples/performance-subscribe/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/performance-subscribe/tests/integration/__init__.py
+++ b/examples/performance-subscribe/tests/integration/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/performance-subscribe/tests/unit/__init__.py
+++ b/examples/performance-subscribe/tests/unit/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Describe your changes

This PR adds an example app which subscribes to a list of signals (from a json file) and prints the values + timestamps of the signals. 

## Issue ticket number and link

#125 

## Checklist - Manual tasks

* [ ] Examples are executing successfully
-> Example setup is outdated and not runnable currently. To test it, copy the code to the vehicle-app-python-template repository and execute it there in the devcontainer.
* [x] Created/updated unit tests. Code Coverage percentage on new code shall be >= 80%.
-> No unit tests needed
* [x] Created/updated integration tests.
-> No unit tests needed
* [x] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
-> Can't test
* [x] Devcontainer can be re-built successfully
* [x] Extended the documentation (e.g. README.md, CONTRIBUTING.md, Velocitas)
-> Added a README for the new example app
