### PR TITLE
Fix yet another regression

### DIFF
--- a/.github/workflows/project-creation.yaml
+++ b/.github/workflows/project-creation.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: eclipse-velocitas/cli
           path: cli
-          ref: v0.7.0
+          ref: v0.11.0
 
       - name: Checkout SDK repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Long story short

- PR #134 was created to fix one regression. 
- Meanwhile another regression occurred, likely because `devenv-devcontainer-setup` that the CLI syncs in one of the actions has a new release (v2.4.5) which seems to cause some problems.
- So even if the CI for PR #134 passed it failed when merged. That this was cause of a new regession could be seen in tests in my own forks where I have a cron job
- The job https://github.com/erikbosch/vehicle-app-python-sdk/actions/runs/9868032931 two days ago passed
- The job https://github.com/erikbosch/vehicle-app-python-sdk/actions/runs/9885340542 running on the same commit yesterday failed
- Updating CLI to latest and greatest fixes this - do not ask me why