### PR TITLE
Update dependencies to fix vulnerabilities

### DIFF
--- a/.project-creation/.skeleton/requirements.in
+++ b/.project-creation/.skeleton/requirements.in
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-grpcio==1.59.0
-protobuf==4.24.4
-cloudevents==1.10.0
-aiohttp==3.9.3
+grpcio==1.64.1
+protobuf==5.27.2
+cloudevents==1.11.0
+aiohttp==3.9.5

--- a/.project-creation/.skeleton/requirements.txt
+++ b/.project-creation/.skeleton/requirements.txt
@@ -4,33 +4,33 @@
 #
 #    pip-compile
 #
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via -r requirements.in
 aiosignal==1.3.1
     # via aiohttp
 async-timeout==4.0.3
     # via aiohttp
-attrs==23.1.0
+attrs==23.2.0
     # via aiohttp
-cloudevents==1.10.0
+cloudevents==1.11.0
     # via -r requirements.in
 deprecation==2.1.0
     # via cloudevents
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-grpcio==1.59.0
+grpcio==1.64.1
     # via -r requirements.in
-idna==3.4
+idna==3.7
     # via yarl
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-packaging==23.2
+packaging==24.1
     # via deprecation
-protobuf==4.24.4
+protobuf==5.27.2
     # via -r requirements.in
-yarl==1.9.2
+yarl==1.9.4
     # via aiohttp

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -3,70 +3,72 @@
 ## Python
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
-|aiohttp|3.9.3|Apache 2.0|
+|aiohttp|3.9.5|Apache 2.0|
 |aiosignal|1.3.1|Apache 2.0|
 |APScheduler|3.10.4|MIT|
 |async-timeout|4.0.3|Apache 2.0|
-|attrs|23.1.0|MIT|
-|build|1.0.3|MIT|
-|cachetools|5.3.2|MIT|
+|attrs|23.2.0|MIT|
+|build|1.2.1|MIT|
+|cachetools|5.4.0|MIT|
 |cfgv|3.4.0|MIT|
 |chardet|5.2.0|LGPL|
 |click|8.1.7|New BSD|
-|cloudevents|1.10.1|Apache 2.0|
+|cloudevents|1.11.0|Apache 2.0|
 |colorama|0.4.6|BSD|
-|coverage|7.4.1|Apache 2.0|
+|coverage|7.6.0|Apache 2.0|
 |Deprecated|1.2.14|MIT|
 |deprecation|2.1.0|Apache 2.0|
 |distlib|0.3.8|Python Software Foundation License|
-|exceptiongroup|1.2.0|MIT|
-|filelock|3.13.1|The Unlicense (Unlicense)|
-|frozenlist|1.4.0|Apache 2.0|
+|exceptiongroup|1.2.2|MIT|
+|filelock|3.15.4|The Unlicense (Unlicense)|
+|frozenlist|1.4.1|Apache 2.0|
 |grpc-stubs|1.53.0.5|MIT|
-|grpcio|1.59.0|Apache 2.0|
-|grpcio-tools|1.59.0|Apache 2.0|
-|identify|2.5.33|MIT|
-|idna|3.4|BSD|
+|grpcio|1.64.1|Apache 2.0|
+|grpcio-tools|1.64.1|Apache 2.0|
+|identify|2.6.0|MIT|
+|idna|3.7|BSD|
+|importlib-metadata|7.1.0|Apache 2.0|
 |iniconfig|2.0.0|MIT|
-|multidict|6.0.4|Apache 2.0|
-|mypy|1.8.0|MIT|
+|multidict|6.0.5|Apache 2.0|
+|mypy|1.11.0|MIT|
 |mypy-extensions|1.0.0|MIT|
-|mypy-protobuf|3.4.0|Apache 2.0|
-|nodeenv|1.8.0|BSD|
-|opentelemetry-api|1.15.0|Apache 2.0|
-|opentelemetry-distro|0.36b0|Apache 2.0|
-|opentelemetry-instrumentation|0.36b0|Apache 2.0|
-|opentelemetry-instrumentation-logging|0.36b0|Apache 2.0|
-|opentelemetry-sdk|1.15.0|Apache 2.0|
-|opentelemetry-semantic-conventions|0.36b0|Apache 2.0|
-|packaging|23.1|Apache 2.0<br/>BSD|
-|paho-mqtt|1.6.1|OSI Approved|
+|mypy-protobuf|3.6.0|Apache 2.0|
+|nodeenv|1.9.1|BSD|
+|opentelemetry-api|1.25.0|Apache 2.0|
+|opentelemetry-distro|0.46b0|Apache 2.0|
+|opentelemetry-instrumentation|0.46b0|Apache 2.0|
+|opentelemetry-instrumentation-logging|0.46b0|Apache 2.0|
+|opentelemetry-sdk|1.25.0|Apache 2.0|
+|opentelemetry-semantic-conventions|0.46b0|Apache 2.0|
+|packaging|24.1|Apache 2.0<br/>BSD|
+|paho-mqtt|2.1.0|OSI Approved|
 |pip|23.0.1|MIT|
-|pip-tools|7.3.0|BSD|
-|platformdirs|4.2.0|MIT|
-|pluggy|1.4.0|MIT|
-|pre-commit|3.6.0|MIT|
-|protobuf|4.21.12|Google License|
-|pyproject-api|1.6.1|MIT|
-|pyproject-hooks|1.0.0|MIT|
-|pytest|7.4.4|MIT|
-|pytest-asyncio|0.23.4|Apache 2.0|
-|pytest-cov|4.1.0|MIT|
+|pip-tools|7.4.1|BSD|
+|platformdirs|4.2.2|MIT|
+|pluggy|1.5.0|MIT|
+|pre-commit|3.8.0|MIT|
+|protobuf|5.27.2|Google License|
+|pyproject-api|1.7.1|MIT|
+|pyproject-hooks|1.1.0|MIT|
+|pytest|8.3.2|MIT|
+|pytest-asyncio|0.23.8|Apache 2.0|
+|pytest-cov|5.0.0|MIT|
 |pytz|2024.1|MIT|
 |PyYAML|6.0.1|MIT|
 |setuptools|65.5.1|MIT|
 |six|1.16.0|MIT|
 |tomli|2.0.1|MIT|
-|tox|4.11.4|MIT|
-|types-Deprecated|1.2.9.20240106|Apache 2.0|
-|types-mock|5.1.0.20240106|Apache 2.0|
-|types-protobuf|4.24.0.20240129|Apache 2.0|
-|typing-extensions|4.7.1|Python Software Foundation License|
+|tox|4.16.0|MIT|
+|types-Deprecated|1.2.9.20240311|Apache 2.0|
+|types-mock|5.1.0.20240425|Apache 2.0|
+|types-protobuf|5.27.0.20240626|Apache 2.0|
+|typing-extensions|4.12.2|Python Software Foundation License|
 |tzlocal|5.2|MIT|
-|virtualenv|20.25.0|MIT|
-|wheel|0.42.0|MIT|
-|wrapt|1.15.0|BSD|
-|yarl|1.9.2|Apache 2.0|
+|virtualenv|20.26.3|MIT|
+|wheel|0.43.0|MIT|
+|wrapt|1.16.0|BSD|
+|yarl|1.9.4|Apache 2.0|
+|zipp|3.19.2|MIT|
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|

--- a/examples/seat-adjuster/requirements.in
+++ b/examples/seat-adjuster/requirements.in
@@ -12,8 +12,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-grpcio==1.59.0
-protobuf==4.24.4
-cloudevents==1.10.0
-aiohttp==3.9.3
-packaging==23.0
+grpcio==1.64.1
+protobuf==5.27.2
+cloudevents==1.11.0
+aiohttp==3.9.5
+packaging==24.1

--- a/examples/seat-adjuster/requirements.txt
+++ b/examples/seat-adjuster/requirements.txt
@@ -4,35 +4,35 @@
 #
 #    pip-compile
 #
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via -r requirements.in
 aiosignal==1.3.1
     # via aiohttp
 async-timeout==4.0.3
     # via aiohttp
-attrs==23.1.0
+attrs==23.2.0
     # via aiohttp
-cloudevents==1.10.0
+cloudevents==1.11.0
     # via -r requirements.in
 deprecation==2.1.0
     # via cloudevents
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-grpcio==1.59.0
+grpcio==1.64.1
     # via -r requirements.in
-idna==3.4
+idna==3.7
     # via yarl
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-packaging==23.0
+packaging==24.1
     # via
     #   -r requirements.in
     #   deprecation
-protobuf==4.24.4
+protobuf==5.27.2
     # via -r requirements.in
-yarl==1.9.2
+yarl==1.9.4
     # via aiohttp

--- a/examples/seat-adjuster/tests/requirements.in
+++ b/examples/seat-adjuster/tests/requirements.in
@@ -17,4 +17,3 @@ pytest-ordering
 pytest-asyncio
 pytest-cov
 types-mock
-packaging==23.0

--- a/examples/seat-adjuster/tests/requirements.txt
+++ b/examples/seat-adjuster/tests/requirements.txt
@@ -4,29 +4,27 @@
 #
 #    pip-compile
 #
-coverage[toml]==7.4.1
+coverage[toml]==7.6.0
     # via
     #   coverage
     #   pytest-cov
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via pytest
 iniconfig==2.0.0
     # via pytest
-packaging==23.0
-    # via
-    #   -r requirements.in
-    #   pytest
-pluggy==1.4.0
+packaging==24.1
     # via pytest
-pytest==7.4.4
+pluggy==1.5.0
+    # via pytest
+pytest==8.3.2
     # via
     #   -r requirements.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-ordering
-pytest-asyncio==0.23.4
+pytest-asyncio==0.23.8
     # via -r requirements.in
-pytest-cov==4.1.0
+pytest-cov==5.0.0
     # via -r requirements.in
 pytest-ordering==0.6
     # via -r requirements.in
@@ -34,5 +32,5 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-mock==5.1.0.20240106
+types-mock==5.1.0.20240425
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=dev
 #
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via velocitas_sdk (setup.py)
 aiosignal==1.3.1
     # via aiohttp
@@ -12,11 +12,11 @@ apscheduler==3.10.4
     # via velocitas_sdk (setup.py)
 async-timeout==4.0.3
     # via aiohttp
-attrs==23.1.0
+attrs==23.2.0
     # via aiohttp
-build==1.0.3
+build==1.2.1
     # via pip-tools
-cachetools==5.3.2
+cachetools==5.4.0
     # via tox
 cfgv==3.4.0
     # via pre-commit
@@ -24,11 +24,11 @@ chardet==5.2.0
     # via tox
 click==8.1.7
     # via pip-tools
-cloudevents==1.10.1
+cloudevents==1.11.0
     # via velocitas_sdk (setup.py)
 colorama==0.4.6
     # via tox
-coverage[toml]==7.4.1
+coverage[toml]==7.6.0
     # via
     #   coverage
     #   pytest-cov
@@ -40,110 +40,114 @@ deprecation==2.1.0
     # via cloudevents
 distlib==0.3.8
     # via virtualenv
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via pytest
-filelock==3.13.1
+filelock==3.15.4
     # via
     #   tox
     #   virtualenv
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
 grpc-stubs==1.53.0.5
     # via velocitas_sdk (setup.py)
-grpcio==1.59.0
+grpcio==1.64.1
     # via
     #   grpc-stubs
     #   grpcio-tools
     #   velocitas_sdk (setup.py)
-grpcio-tools==1.59.0
+grpcio-tools==1.64.1
     # via velocitas_sdk (setup.py)
-identify==2.5.33
+identify==2.6.0
     # via pre-commit
-idna==3.4
+idna==3.7
     # via yarl
+importlib-metadata==7.1.0
+    # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-mypy==1.8.0
+mypy==1.11.0
     # via velocitas_sdk (setup.py)
 mypy-extensions==1.0.0
     # via mypy
-mypy-protobuf==3.4.0
+mypy-protobuf==3.6.0
     # via velocitas_sdk (setup.py)
-nodeenv==1.8.0
+nodeenv==1.9.1
     # via pre-commit
-opentelemetry-api==1.15.0
+opentelemetry-api==1.25.0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   velocitas_sdk (setup.py)
-opentelemetry-distro==0.36b0
+opentelemetry-distro==0.46b0
     # via velocitas_sdk (setup.py)
-opentelemetry-instrumentation==0.36b0
+opentelemetry-instrumentation==0.46b0
     # via
     #   opentelemetry-distro
     #   opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.36b0
+opentelemetry-instrumentation-logging==0.46b0
     # via velocitas_sdk (setup.py)
-opentelemetry-sdk==1.15.0
+opentelemetry-sdk==1.25.0
     # via
     #   opentelemetry-distro
     #   velocitas_sdk (setup.py)
-opentelemetry-semantic-conventions==0.36b0
+opentelemetry-semantic-conventions==0.46b0
     # via opentelemetry-sdk
-packaging==23.1
+packaging==24.1
     # via
     #   build
     #   deprecation
     #   pyproject-api
     #   pytest
     #   tox
-paho-mqtt==1.6.1
+paho-mqtt==2.1.0
     # via velocitas_sdk (setup.py)
-pip-tools==7.3.0
+pip-tools==7.4.1
     # via velocitas_sdk (setup.py)
-platformdirs==4.2.0
+platformdirs==4.2.2
     # via
     #   tox
     #   virtualenv
-pluggy==1.4.0
+pluggy==1.5.0
     # via
     #   pytest
     #   tox
-pre-commit==3.6.0
+pre-commit==3.8.0
     # via velocitas_sdk (setup.py)
-protobuf==4.21.12
+protobuf==5.27.2
     # via
     #   grpcio-tools
     #   mypy-protobuf
     #   velocitas_sdk (setup.py)
-pyproject-api==1.6.1
+pyproject-api==1.7.1
     # via tox
-pyproject-hooks==1.0.0
-    # via build
-pytest==7.4.4
+pyproject-hooks==1.1.0
+    # via
+    #   build
+    #   pip-tools
+pytest==8.3.2
     # via
     #   pytest-asyncio
     #   pytest-cov
     #   velocitas_sdk (setup.py)
-pytest-asyncio==0.23.4
+pytest-asyncio==0.23.8
     # via velocitas_sdk (setup.py)
-pytest-cov==4.1.0
+pytest-cov==5.0.0
     # via velocitas_sdk (setup.py)
 pytz==2024.1
     # via apscheduler
 pyyaml==6.0.1
     # via pre-commit
 six==1.16.0
-    # via
-    #   apscheduler
+    # via apscheduler
 tomli==2.0.1
     # via
     #   build
@@ -151,35 +155,36 @@ tomli==2.0.1
     #   mypy
     #   pip-tools
     #   pyproject-api
-    #   pyproject-hooks
     #   pytest
     #   tox
-tox==4.11.4
+tox==4.16.0
     # via velocitas_sdk (setup.py)
-types-deprecated==1.2.9.20240106
+types-deprecated==1.2.9.20240311
     # via velocitas_sdk (setup.py)
-types-mock==5.1.0.20240106
+types-mock==5.1.0.20240425
     # via velocitas_sdk (setup.py)
-types-protobuf==4.24.0.20240129
+types-protobuf==5.27.0.20240626
     # via mypy-protobuf
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via
     #   mypy
     #   opentelemetry-sdk
 tzlocal==5.2
     # via apscheduler
-virtualenv==20.25.0
+virtualenv==20.26.3
     # via
     #   pre-commit
     #   tox
-wheel==0.42.0
+wheel==0.43.0
     # via pip-tools
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   deprecated
     #   opentelemetry-instrumentation
-yarl==1.9.2
+yarl==1.9.4
     # via aiohttp
+zipp==3.19.2
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,15 @@
 from setuptools import setup
 
 requirements = [
-    "grpcio>=1.59.0",
-    "protobuf>=3.19.4",
-    "cloudevents>=1.10.0",
-    "aiohttp==3.9.3",
-    "paho-mqtt>=1.6.1,<2",
-    "opentelemetry-distro<=0.36b0",
-    "opentelemetry-instrumentation-logging<=0.36b0",
-    "opentelemetry-sdk<=1.15.0",
-    "opentelemetry-api<=1.15.0",
+    "grpcio==1.64.1",
+    "protobuf==5.27.2",
+    "cloudevents==1.11.0",
+    "aiohttp==3.9.5",
+    "paho-mqtt==2.1.0",
+    "opentelemetry-distro==0.46b0",
+    "opentelemetry-instrumentation-logging==0.46b0",
+    "opentelemetry-sdk==1.25.0",
+    "opentelemetry-api==1.25.0",
 ]
 
 extra_requirements = {

--- a/velocitas_sdk/native/locator.py
+++ b/velocitas_sdk/native/locator.py
@@ -38,7 +38,7 @@ class NativeServiceLocator(ServiceLocator):
             except KeyError:
                 logger.warning(
                     """Can't find the service location for %s, make sure to set the
-                    necessary env variables for all depemdencies""",
+                    necessary env variables for all dependencies""",
                     service_name,
                 )
 

--- a/velocitas_sdk/native/middleware.py
+++ b/velocitas_sdk/native/middleware.py
@@ -12,6 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
 from urllib.parse import urlparse
 
 from velocitas_sdk.base import Middleware, MiddlewareType
@@ -31,7 +32,12 @@ class NativeMiddleware(Middleware):
         _address = self.service_locator.get_service_location("mqtt")
         _port = urlparse(_address).port
         _hostname = urlparse(_address).hostname
-        self.pubsub_client = MqttClient(_port, _hostname)
+
+        if _hostname is None:
+            print("No hostname")
+            sys.exit(-1)
+
+        self.pubsub_client = MqttClient(hostname=_hostname, port=_port)
 
     async def start(self):
         pass

--- a/velocitas_sdk/native/mqtt.py
+++ b/velocitas_sdk/native/mqtt.py
@@ -34,7 +34,7 @@ class MqttTopicSubscription:
 class MqttClient(PubSubClient):
     """This class is a wrapper for the on_message callback of the MQTT broker."""
 
-    def __init__(self, port: Optional[int] = None, hostname: Optional[str] = None):
+    def __init__(self, hostname: str, port: Optional[int] = None):
         self._port = port
         self._hostname = hostname
         self._topics_to_subscribe: list[MqttTopicSubscription] = []
@@ -44,8 +44,12 @@ class MqttClient(PubSubClient):
         self._sub_client.on_connect = self.on_connect
         self._sub_client.on_disconnect = self.on_disconnect
 
-        self._sub_client.connect(self._hostname, self._port)
-        self._pub_client.connect(self._hostname, self._port)
+        if self._port is None:
+            self._sub_client.connect(self._hostname)
+            self._pub_client.connect(self._hostname)
+        else:
+            self._sub_client.connect(self._hostname, self._port)
+            self._pub_client.connect(self._hostname, self._port)
 
     def on_connect(self, client, userdata, flags, rc):
         if rc == 0:

--- a/velocitas_sdk/util/log.py
+++ b/velocitas_sdk/util/log.py
@@ -71,6 +71,7 @@ def set_opentelemetry_factory_span(span):
 
         record.otelSpanID = "0"
         record.otelTraceID = "0"
+        record.otelTraceSampled = True
         ctx = span.get_span_context()
         if ctx != INVALID_SPAN_CONTEXT:
             record.otelSpanID = format(ctx.span_id, "016x")


### PR DESCRIPTION
Updating dependencies to address vulnerabilities, if merged and released it may also fix some vulnerabilities in https://github.com/eclipse-velocitas/vehicle-app-python-template as that repo depends on this repo. Doing necessary refactoring.

All examples tested by trying to build and start-up them, but not by actually sending messages on MQTT, gRPC and similar. Some problems detected and fixes exist in https://github.com/eclipse-velocitas/vehicle-app-python-sdk/pull/141 but no problems found related to the changes in this repository. 

After a discussion in ETAS dev team proposing to change to fixed versions also in *.in/setup.py. I updated all *.in/setup.py files to what was used after the `--upgrade` I did with pip-compile before testing.

**Background**

Some time ago we added in #119 a fix to https://github.com/eclipse-velocitas/vehicle-app-python-template/issues/225 by putting an upper limit on used paho-version, due to a backward incompatible change in paho-mqtt. Now that has partially changed in paho-mqtt 2.1, see:

- https://github.com/eclipse/paho.mqtt.python/releases/tag/v2.1.0
- https://github.com/eclipse/paho.mqtt.python/pull/831

So now CallbackAPIVersion.VERSION1 is default.