### PR TITLE
Update release workflow with pypi push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at
@@ -12,56 +12,92 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Release workflow
+name: Github Release and PyPi Publish
 
 on:
-  release:
-    types: [published, edited]
+  workflow_dispatch:
+  push:
+   tags:
+     - "v*.*.*"
 
 jobs:
-  release-package:
-    name: Generate package binaries
-    runs-on: ubuntu-latest
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-22.04
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Install pypa/build
+      run: pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: |
+          dist/
+          LICENSE
+          NOTICE.md
 
-      - name: Initialize python
-        uses: actions/setup-python@v5
-        with:
-            python-version: "3.10"
+  publish-to-pypi:
+    name: Publish 🐍 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-22.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/velocitas-sdk
 
-      - name: Install Dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
+    permissions:
+      id-token: write
 
-      - name: Set tags output
-        id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+    steps:
+    - name: Download dists folder
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: python-package/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: python-package/dist
 
-      - name: Check output
-        env:
-          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-        run: |
-          echo $RELEASE_VERSION
-          echo ${{ steps.vars.outputs.tag }}
+  github-release:
+    name: >-
+      Create GitHub Release
+    needs:
+    - build
+    runs-on: ubuntu-22.04
 
-      - name: Test setup.cfg execution
-        run: |
-          sed -i -e 's/@tag/${{ steps.vars.outputs.tag }}/g' ./setup.py
-          python3 setup.py sdist
+    permissions:
+      contents: write
+      id-token: write
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: release
-          path: ./dist
-
-      - name: Upload assets
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            ./dist/*
+    steps:
+    - name: Download dists folder
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: python-package/
+    - name: Sign the dists with Sigstore
+      # If running on your own fork/organization
+      # you must assure that sigstore has been added as authroized OAuth app in Github
+      # Can be triggered by a manual run on CLI like "sigstore sign <somefile>"
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./python-package/dist/*.tar.gz
+          ./python-package/dist/*.whl
+    - name: Create release
+      id: create_release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          python-package/dist/**
+          python-package/LICENSE
+          python-package/NOTICE.md

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -7,7 +7,7 @@
 |aiosignal|1.3.1|Apache 2.0|
 |APScheduler|3.10.4|MIT|
 |async-timeout|4.0.3|Apache 2.0|
-|attrs|23.2.0|MIT|
+|attrs|24.2.0|MIT|
 |build|1.2.1|MIT|
 |cachetools|5.4.0|MIT|
 |cfgv|3.4.0|MIT|
@@ -15,7 +15,7 @@
 |click|8.1.7|New BSD|
 |cloudevents|1.11.0|Apache 2.0|
 |colorama|0.4.6|BSD|
-|coverage|7.6.0|Apache 2.0|
+|coverage|7.6.1|Apache 2.0|
 |Deprecated|1.2.14|MIT|
 |deprecation|2.1.0|Apache 2.0|
 |distlib|0.3.8|Python Software Foundation License|
@@ -30,7 +30,7 @@
 |importlib-metadata|7.1.0|Apache 2.0|
 |iniconfig|2.0.0|MIT|
 |multidict|6.0.5|Apache 2.0|
-|mypy|1.11.0|MIT|
+|mypy|1.11.1|MIT|
 |mypy-extensions|1.0.0|MIT|
 |mypy-protobuf|3.6.0|Apache 2.0|
 |nodeenv|1.9.1|BSD|
@@ -54,18 +54,18 @@
 |pytest-asyncio|0.23.8|Apache 2.0|
 |pytest-cov|5.0.0|MIT|
 |pytz|2024.1|MIT|
-|PyYAML|6.0.1|MIT|
+|PyYAML|6.0.2|MIT|
 |setuptools|65.5.1|MIT|
 |six|1.16.0|MIT|
 |tomli|2.0.1|MIT|
-|tox|4.16.0|MIT|
+|tox|4.17.1|MIT|
 |types-Deprecated|1.2.9.20240311|Apache 2.0|
 |types-mock|5.1.0.20240425|Apache 2.0|
 |types-protobuf|5.27.0.20240626|Apache 2.0|
 |typing-extensions|4.12.2|Python Software Foundation License|
 |tzlocal|5.2|MIT|
 |virtualenv|20.26.3|MIT|
-|wheel|0.43.0|MIT|
+|wheel|0.44.0|MIT|
 |wrapt|1.16.0|BSD|
 |yarl|1.9.4|Apache 2.0|
 |zipp|3.19.2|MIT|
@@ -73,6 +73,7 @@
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
 |actions/checkout|v4|MIT License|
+|actions/download-artifact|v4|MIT License|
 |actions/setup-java|v4|MIT License|
 |actions/setup-node|v4|MIT License|
 |actions/setup-python|v5|MIT License|
@@ -82,4 +83,6 @@
 |github/codeql-action|v3|MIT License|
 |mikepenz/action-junit-report|v4|Apache License 2.0|
 |pre-commit/action|v3.0.1|MIT License|
-|softprops/action-gh-release|v1|MIT License|
+|pypa/gh-action-pypi-publish|release/v1|BSD 3-Clause "New" or "Revised" License|
+|sigstore/gh-action-sigstore-python|v3.0.0|Apache License 2.0|
+|softprops/action-gh-release|v2|MIT License|

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ apscheduler==3.10.4
     # via velocitas_sdk (setup.py)
 async-timeout==4.0.3
     # via aiohttp
-attrs==23.2.0
+attrs==24.2.0
     # via aiohttp
 build==1.2.1
     # via pip-tools
@@ -28,7 +28,7 @@ cloudevents==1.11.0
     # via velocitas_sdk (setup.py)
 colorama==0.4.6
     # via tox
-coverage[toml]==7.6.0
+coverage[toml]==7.6.1
     # via
     #   coverage
     #   pytest-cov
@@ -71,7 +71,7 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-mypy==1.11.0
+mypy==1.11.1
     # via velocitas_sdk (setup.py)
 mypy-extensions==1.0.0
     # via mypy
@@ -144,7 +144,7 @@ pytest-cov==5.0.0
     # via velocitas_sdk (setup.py)
 pytz==2024.1
     # via apscheduler
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via pre-commit
 six==1.16.0
     # via apscheduler
@@ -157,7 +157,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tox==4.16.0
+tox==4.17.1
     # via velocitas_sdk (setup.py)
 types-deprecated==1.2.9.20240311
     # via velocitas_sdk (setup.py)
@@ -175,7 +175,7 @@ virtualenv==20.26.3
     # via
     #   pre-commit
     #   tox
-wheel==0.43.0
+wheel==0.44.0
     # via pip-tools
 wrapt==1.16.0
     # via

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="velocitas_sdk",
-    version="0.15.0",
+    version="0.15.2",
     description="A Python SDK for Vehicle app",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Update based on https://github.com/eclipse-velocitas/velocitas-lib/blob/main/.github/workflows/release.yml,. Only some minor changes.

Tested at https://github.com/erikbosch/vehicle-app-python-sdk
Pypi upload verified at https://pypi.org/project/velocitas-sdk/#history

Note that this gives a somewhat different release flow compared to before. Previously you had to create a Github release manually, then the action populated it. Now you instead need to create/push a tag