### PR TITLE
Fix test case regression

### DIFF
--- a/.project-creation/test/test_integration.py
+++ b/.project-creation/test/test_integration.py
@@ -36,7 +36,7 @@ def test_files_in_place():
     is_file(".devcontainer/scripts/configure-proxies.sh")
     is_file(".devcontainer/scripts/container-set.sh")
     is_file(".devcontainer/scripts/onCreateCommand.sh")
-    is_file(".devcontainer/scripts/postStartCommand.sh")
+    is_file(".devcontainer/scripts/upgrade-cli.sh")
     is_file(".devcontainer/devcontainer.json")
     is_file(".devcontainer/Dockerfile")
 


### PR DESCRIPTION
In https://github.com/eclipse-velocitas/devenv-devcontainer-setup/releases/tag/v2.5.0 files have been removed, and when we do create we automatically updates to latest and greatest
