### PR TITLE
Updating dependencies to fix vulnerabilities

### DIFF
--- a/.project-creation/.skeleton/requirements-velocitas.txt
+++ b/.project-creation/.skeleton/requirements-velocitas.txt
@@ -1,1 +1,1 @@
-velocitas-sdk==0.14.1
+velocitas-sdk==0.15.4

--- a/examples/seat-adjuster/requirements-velocitas.txt
+++ b/examples/seat-adjuster/requirements-velocitas.txt
@@ -1,1 +1,1 @@
-velocitas-sdk==0.14.1
+velocitas-sdk==0.15.4


### PR DESCRIPTION
There are some hypothetical vulnerabilities in v0.14.1 of this repo, so the examples and skeleton should preferably not use that one. I have just updated it to last release version (examples are anyway partially broken, see #141 )

We should better discuss how to handle these references when we do releases. Should we always update them before/after we create a new pypi release? Or should we in these two cases just remove version so we use "latest and greatest" velocitas-sdk