### PR TITLE
Fix Databroker regression

### DIFF
--- a/.vscode/scripts/run-vehicledatabroker.sh
+++ b/.vscode/scripts/run-vehicledatabroker.sh
@@ -41,4 +41,5 @@ docker run \
   -e KUKSA_DATA_BROKER_PORT \
   -e RUST_LOG \
   --network host \
-  $DATABROKER_IMAGE:$DATABROKER_TAG
+  $DATABROKER_IMAGE:$DATABROKER_TAG \
+  --enable-databroker-v1


### PR DESCRIPTION
CLI updates runtime, which updates Databroker version, which causes test to fail here, as new Databroker does not have old API enabled by default
